### PR TITLE
Session key is no longer encoded in the constructor, several changes …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - "7.1"
   - "7.2"
   - "7.3"
+  - "7.4"
 
 before_install:
   - sudo apt-get update
@@ -22,7 +23,7 @@ before_install:
     cd ..;
     pecl install libsodium-1.0.7;
     fi
-  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]; then
+  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]; then
     git checkout 1.0.18;
     ./autogen.sh;
     ./configure && make check;

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ dist: xenial
 sudo: required
 
 php:
-  - "7.0"
-  - "7.1"
   - "7.2"
   - "7.3"
   - "7.4"
@@ -15,14 +13,6 @@ before_install:
   - sudo apt-get install make build-essential automake php-dev php-pear
   - git clone git://github.com/jedisct1/libsodium.git
   - cd libsodium
-  - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]; then
-    git checkout 1.0.10;
-    ./autogen.sh;
-    ./configure && make check;
-    sudo make install;
-    cd ..;
-    pecl install libsodium-1.0.7;
-    fi
   - if [ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ] || [ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]; then
     git checkout 1.0.18;
     ./autogen.sh;

--- a/bundle/Spec/CirclicalUser/Entity/UserResetTokenSpec.php
+++ b/bundle/Spec/CirclicalUser/Entity/UserResetTokenSpec.php
@@ -30,7 +30,7 @@ class UserResetTokenSpec extends ObjectBehavior
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 1;
 
         $this->rawKeyMaterial = KeyFactory::generateEncryptionKey()->getRawKeyMaterial();
-        $authenticationRecord->getSessionKey()->willReturn($this->rawKeyMaterial);
+        $authenticationRecord->getRawSessionKey()->willReturn($this->rawKeyMaterial);
         $authenticationRecord->getUserId()->willReturn(1);
         $this->beConstructedWith($authenticationRecord, '10.10.1.1');
 
@@ -68,7 +68,7 @@ class UserResetTokenSpec extends ObjectBehavior
         $token = $property->getValue($this->getWrappedObject());
 
         // the authentication record was manipulated during the operation
-        $authenticationRecord->getSessionKey()->willReturn(KeyFactory::generateEncryptionKey()->getRawKeyMaterial());
+        $authenticationRecord->getRawSessionKey()->willReturn(KeyFactory::generateEncryptionKey()->getRawKeyMaterial());
 
         $this->shouldThrow(InvalidResetTokenException::class)->during(
             'isValid',

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": "^7.0.0",
+    "php": "^7.2.0",
     "zendframework/zend-eventmanager": "^3.0",
     "zendframework/zend-servicemanager": "^3.0",
     "zendframework/zend-mvc": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpspec/phpspec": "^3.1",
-    "leanphp/phpspec-code-coverage": "3.1.1",
+    "phpspec/phpspec": "6.1.1",
+    "friends-of-phpspec/phpspec-code-coverage": "@stable",
     "codacy/coverage": "^1.0",
     "paragonie/passwdqc": "^0.2.0"
   },

--- a/src/CirclicalUser/Entity/Authentication.php
+++ b/src/CirclicalUser/Entity/Authentication.php
@@ -4,6 +4,7 @@ namespace CirclicalUser\Entity;
 
 use CirclicalUser\Provider\AuthenticationRecordInterface;
 use Doctrine\ORM\Mapping as ORM;
+use phpDocumentor\Reflection\Types\Void_;
 
 /**
  * CirclicalUser\Entity\Authentication
@@ -20,36 +21,37 @@ class Authentication implements AuthenticationRecordInterface
      * @ORM\Column(type="integer", nullable=false, length=10, options={"unsigned"=true})
      */
     protected $user_id;
-    
-    
+
+
     /**
      * @var string
      * @ORM\Column(type="string", unique=true, nullable=false, length=254)
      */
     protected $username;
-    
-    
+
+
     /**
      * @var string
      * @ORM\Column(type="string", nullable=false, length=255)
      */
     protected $hash;
-    
-    
+
+
     /**
      * @var string
+     * A base64-encoded representation of the user's session key
      * @ORM\Column(type="string", nullable=true, length=192, options={"fixed" = true})
      */
     protected $session_key;
-    
-    
+
+
     /**
      * @var string
      * @ORM\Column(type="string", nullable=true, length=32, options={"fixed" = true})
      */
     protected $reset_hash;
-    
-    
+
+
     /**
      * @var string
      * @ORM\Column(type="datetime", nullable=true )
@@ -57,12 +59,12 @@ class Authentication implements AuthenticationRecordInterface
     protected $reset_expiry;
 
 
-    public function __construct( $userId, $username, $hash, $sessionKey )
+    public function __construct(int $userId, string $username, string $hash, string $encodedSessionKey)
     {
         $this->user_id = $userId;
         $this->username = $username;
         $this->hash = $hash;
-        $this->session_key = base64_encode($sessionKey);
+        $this->session_key = $encodedSessionKey;
     }
 
 
@@ -73,7 +75,7 @@ class Authentication implements AuthenticationRecordInterface
     {
         return $this->user_id;
     }
-    
+
     /**
      * @param int $user_id
      */
@@ -81,15 +83,15 @@ class Authentication implements AuthenticationRecordInterface
     {
         $this->user_id = $user_id;
     }
-    
+
     /**
      * @return string
      */
-    public function getUsername() : string
+    public function getUsername(): string
     {
         return $this->username;
     }
-    
+
     /**
      * @param string $username
      */
@@ -97,40 +99,44 @@ class Authentication implements AuthenticationRecordInterface
     {
         $this->username = $username;
     }
-    
-    /**
-     * @return string
-     */
-    public function getHash()
+
+    public function getHash(): string
     {
         return $this->hash;
     }
-    
-    /**
-     * @param string $hash
-     */
-    public function setHash($hash)
+
+    public function setHash(string $hash)
     {
         $this->hash = $hash;
     }
 
-    /**
-     * @return string
-     */
-    public function getSessionKey() : string
+    public function getSessionKey(): string
+    {
+        return $this->session_key;
+    }
+
+    public function getRawSessionKey(): string
     {
         return base64_decode($this->session_key);
     }
 
     /**
      * Value gets Base64-encoded for storage
-     * @param $session_key
      */
-    public function setSessionKey($session_key)
+    public function setSessionKey(string $sessionKey)
     {
-        $this->session_key = base64_encode($session_key);
+        $this->session_key = $sessionKey;
     }
-    
+
+    /**
+     * Instead of setting a bas64-encoded string, you can set the raw bytes for the key.
+     * This setter will base64-encode.
+     */
+    public function setRawSessionKey(string $sessionKey)
+    {
+        $this->session_key = base64_encode($sessionKey);
+    }
+
     /**
      * @return string
      */
@@ -138,7 +144,7 @@ class Authentication implements AuthenticationRecordInterface
     {
         return $this->reset_hash;
     }
-    
+
     /**
      * @param string $reset_hash
      */
@@ -146,7 +152,7 @@ class Authentication implements AuthenticationRecordInterface
     {
         $this->reset_hash = $reset_hash;
     }
-    
+
     /**
      * @return string
      */
@@ -154,7 +160,7 @@ class Authentication implements AuthenticationRecordInterface
     {
         return $this->reset_expiry;
     }
-    
+
     /**
      * @param string $reset_expiry
      */

--- a/src/CirclicalUser/Entity/UserResetToken.php
+++ b/src/CirclicalUser/Entity/UserResetToken.php
@@ -78,7 +78,7 @@ class UserResetToken implements UserResetTokenInterface
 
         $fingerprint = $this->getFingerprint();
 
-        $key = new EncryptionKey(new HiddenString($authentication->getSessionKey()));
+        $key = new EncryptionKey(new HiddenString($authentication->getRawSessionKey()));
         $this->token = base64_encode(Crypto::encrypt(new HiddenString(json_encode([
             'fingerprint' => $fingerprint,
             'timestamp' => $this->request_time->format('U'),
@@ -128,7 +128,7 @@ class UserResetToken implements UserResetTokenInterface
 
         try {
             $encryptedJson = @base64_decode($checkToken);
-            $key = new EncryptionKey(new HiddenString($authenticationRecord->getSessionKey()));
+            $key = new EncryptionKey(new HiddenString($authenticationRecord->getRawSessionKey()));
             $jsonString = Crypto::decrypt($encryptedJson, $key);
         } catch (\Exception $x) {
             throw new InvalidResetTokenException();

--- a/src/CirclicalUser/Mapper/AuthenticationMapper.php
+++ b/src/CirclicalUser/Mapper/AuthenticationMapper.php
@@ -41,6 +41,6 @@ class AuthenticationMapper extends AbstractDoctrineMapper implements Authenticat
      */
     public function create($userId, $username, $hash, $rawKey): AuthenticationRecordInterface
     {
-        return new Authentication($userId, $username, $hash, $rawKey);
+        return new Authentication($userId, $username, $hash, base64_encode($rawKey));
     }
 }

--- a/src/CirclicalUser/Provider/AuthenticationRecordInterface.php
+++ b/src/CirclicalUser/Provider/AuthenticationRecordInterface.php
@@ -7,11 +7,15 @@ interface AuthenticationRecordInterface
 
     public function setUsername($usernameOrEmail);
 
-    public function getSessionKey() : string;
+    public function getSessionKey(): string;
 
-    public function setSessionKey($rawKey);
+    public function getRawSessionKey(): string;
 
-    public function getUsername() : string;
+    public function setSessionKey(string $sessionKey);
+
+    public function setRawSessionKey(string $rawKey);
+
+    public function getUsername(): string;
 
     public function getUserId();
 

--- a/src/CirclicalUser/Service/AuthenticationService.php
+++ b/src/CirclicalUser/Service/AuthenticationService.php
@@ -262,7 +262,7 @@ class AuthenticationService
     private function setSessionCookies(AuthenticationRecordInterface $authentication)
     {
         $systemKey = new EncryptionKey($this->systemEncryptionKey);
-        $sessionKey = new HiddenString($authentication->getSessionKey());
+        $sessionKey = new HiddenString($authentication->getRawSessionKey());
         $userKey = new EncryptionKey($sessionKey);
         $hashCookieName = hash_hmac('sha256', $sessionKey . $authentication->getUsername(), $systemKey);
         $userTuple = base64_encode(Crypto::encrypt(new HiddenString($authentication->getUserId() . ':' . $hashCookieName), $systemKey));
@@ -391,7 +391,7 @@ class AuthenticationService
                 throw new \Exception();
             }
 
-            $userKey = new EncryptionKey(new HiddenString($auth->getSessionKey()));
+            $userKey = new EncryptionKey(new HiddenString($auth->getRawSessionKey()));
             $hashPass = hash_equals(
                 hash_hmac('sha256', $_COOKIE[$hashCookieName], $userKey),
                 $_COOKIE[self::COOKIE_VERIFY_B]
@@ -593,7 +593,7 @@ class AuthenticationService
     private function resetAuthenticationKey(AuthenticationRecordInterface $auth): AuthenticationRecordInterface
     {
         $key = KeyFactory::generateEncryptionKey();
-        $auth->setSessionKey($key->getRawKeyMaterial());
+        $auth->setRawSessionKey($key->getRawKeyMaterial());
         $this->authenticationProvider->update($auth);
 
         return $auth;


### PR DESCRIPTION
The old setSessionKey(rawBytes) becomes setRawSessionKey(rawBytes).
The new setSessionKey(string) expects that the string be base64 encoded.
PHPSpec moved to 6.1.1
Coverage library updated.