### PR TITLE
PHP8 Support

### DIFF
--- a/.github/workflows/phpspec-task.yml
+++ b/.github/workflows/phpspec-task.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-18.04 ]
-        php-versions: [ '7.4' ]
+        php-versions: [ '7.4', '8.0' ]
     name: Evaluate Behavior, ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     steps:
       # Get the source code

--- a/bundle/Spec/CirclicalUser/ModuleSpec.php
+++ b/bundle/Spec/CirclicalUser/ModuleSpec.php
@@ -3,8 +3,8 @@
 namespace Spec\CirclicalUser;
 
 use CirclicalUser\Listener\AccessListener;
+use CirclicalUser\Module;
 use PhpSpec\ObjectBehavior;
-use Laminas\Console\Console;
 use Laminas\EventManager\EventManager;
 use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
@@ -22,10 +22,14 @@ class ModuleSpec extends ObjectBehavior
         $this->getConfig()->shouldBeArray();
     }
 
-    public function it_has_a_bootstrap_method(MvcEvent $event, Application $application, ServiceLocatorInterface $serviceLocator,
-                                              AccessListener $listener, EventManager $eventManager )
-    {
-        Console::overrideIsConsole(false);
+    public function it_has_a_bootstrap_method(
+        MvcEvent $event,
+        Application $application,
+        ServiceLocatorInterface $serviceLocator,
+        AccessListener $listener,
+        EventManager $eventManager
+    ) {
+        Module::overrideIsConsole(false);
         $application->getEventManager()->willReturn($eventManager);
         $serviceLocator->get(AccessListener::class)->willReturn($listener);
         $application->getServiceManager()->willReturn($serviceLocator);
@@ -36,11 +40,14 @@ class ModuleSpec extends ObjectBehavior
         $this->onBootstrap($event);
     }
 
-    public function it_aborts_bootstrap_on_console(MvcEvent $event, Application $application, ServiceLocatorInterface $serviceLocator,
-                                              AccessListener $listener, EventManager $eventManager )
-    {
-
-        Console::overrideIsConsole(true);
+    public function it_aborts_bootstrap_on_console(
+        MvcEvent $event,
+        Application $application,
+        ServiceLocatorInterface $serviceLocator,
+        AccessListener $listener,
+        EventManager $eventManager
+    ) {
+        Module::overrideIsConsole(true);
         $application->getEventManager()->willReturn($eventManager);
         $serviceLocator->get(AccessListener::class)->willReturn($listener);
         $application->getServiceManager()->willReturn($serviceLocator);
@@ -50,6 +57,5 @@ class ModuleSpec extends ObjectBehavior
 
         $this->onBootstrap($event);
     }
-
 
 }

--- a/bundle/Spec/CirclicalUser/Service/AuthenticationServiceSpec.php
+++ b/bundle/Spec/CirclicalUser/Service/AuthenticationServiceSpec.php
@@ -443,8 +443,41 @@ class AuthenticationServiceSpec extends ObjectBehavior
         $this->shouldThrow(PersistedUserRequiredException::class)->during('create', [$otherUser, 'whoami', 'nobody']);
     }
 
-    public function it_will_create_new_auth_records_with_strong_passwords($authenticationMapper, User $user5, AuthenticationRecordInterface $newAuth, $userMapper, $tokenMapper)
-    {
+//
+// Test paused, as passwdqc does not yet have php8 support
+//
+//    public function it_will_create_new_auth_records_with_strong_passwords($authenticationMapper, User $user5, AuthenticationRecordInterface $newAuth, $userMapper, $tokenMapper)
+//    {
+//        $this->beConstructedWith(
+//            $authenticationMapper,
+//            $userMapper,
+//            $tokenMapper,
+//            $this->systemEncryptionKey->getRawKeyMaterial(),
+//            false,
+//            false,
+//            new Passwdqc(),
+//            true,
+//            true,
+//            'None'
+//        );
+//
+//        $newAuth->getRawSessionKey()->willReturn(KeyFactory::generateEncryptionKey()->getRawKeyMaterial());
+//        $newAuth->getUsername()->willReturn('email');
+//        $newAuth->getUserId()->willReturn(5);
+//        $user5->getId()->willReturn(5);
+//
+//        $authenticationMapper->save(Argument::type(AuthenticationRecordInterface::class))->shouldBeCalled();
+//        $authenticationMapper->create(Argument::type('integer'), Argument::type('string'), Argument::type('string'), Argument::type('string'))->willReturn($newAuth);
+//        $this->create($user5, 'userC', 'beestring')->shouldBeAnInstanceOf(AuthenticationRecordInterface::class);
+//    }
+
+    public function it_wont_create_new_auth_records_with_weak_passwords(
+        AuthenticationMapper $authenticationMapper,
+        User $user5,
+        AuthenticationRecordInterface $newAuth,
+        UserMapper $userMapper,
+        UserResetTokenMapper $tokenMapper
+    ) {
         $this->beConstructedWith(
             $authenticationMapper,
             $userMapper,
@@ -452,32 +485,7 @@ class AuthenticationServiceSpec extends ObjectBehavior
             $this->systemEncryptionKey->getRawKeyMaterial(),
             false,
             false,
-            new Passwdqc(),
-            true,
-            true,
-            'None'
-        );
-
-        $newAuth->getRawSessionKey()->willReturn(KeyFactory::generateEncryptionKey()->getRawKeyMaterial());
-        $newAuth->getUsername()->willReturn('email');
-        $newAuth->getUserId()->willReturn(5);
-        $user5->getId()->willReturn(5);
-
-        $authenticationMapper->save(Argument::type(AuthenticationRecordInterface::class))->shouldBeCalled();
-        $authenticationMapper->create(Argument::type('integer'), Argument::type('string'), Argument::type('string'), Argument::type('string'))->willReturn($newAuth);
-        $this->create($user5, 'userC', 'beestring')->shouldBeAnInstanceOf(AuthenticationRecordInterface::class);
-    }
-
-    public function it_wont_create_new_auth_records_with_weak_passwords($authenticationMapper, User $user5, AuthenticationRecordInterface $newAuth, UserMapper $userMapper, UserResetTokenMapper $tokenMapper)
-    {
-        $this->beConstructedWith(
-            $authenticationMapper,
-            $userMapper,
-            $tokenMapper,
-            $this->systemEncryptionKey->getRawKeyMaterial(),
-            false,
-            false,
-            new Passwdqc(),
+            new Zxcvbn([]),
             true,
             true,
             'None'

--- a/composer.json
+++ b/composer.json
@@ -1,63 +1,80 @@
 {
-    "name": "saeven/zf3-circlical-user",
-    "description": "Complete user entity, rights, and access module for Laminas",
-    "type": "library",
-    "license": "MPL-2.0",
-    "homepage": "https://github.com/Saeven/zf3-circlical-user",
-    "keywords": [
-        "user",
-        "zf3",
-        "user management",
-        "acl",
-        "rbac",
-        "bjyauthorize",
-        "authorization",
-        "auth"
-    ],
-    "authors": [
-        {
-            "name": "Alexandre Lemaire",
-            "email": "alemaire@circlical.com",
-            "homepage": "http://circlical.com/",
-            "role": "Paper Stapler"
-        }
-    ],
-    "require": {
-        "ext-json": "*",
-        "php": "^7.4.0 | ^8",
-        "laminas/laminas-eventmanager": "^3.0",
-        "laminas/laminas-servicemanager": "^3.0",
-        "laminas/laminas-mvc": "^3.0",
-        "laminas/laminas-console": "^2.6",
-        "laminas/laminas-view": "^2.8",
-        "laminas/laminas-http": "^2.5",
-        "doctrine/doctrine-orm-module": "^1.1||2.*||4.*",
-        "doctrine/doctrine-module": "^1.2||2.*||4.*",
-        "doctrine/orm": "2.*",
-        "paragonie/halite": "^3.3",
-        "ramsey/uuid": "^3.5 | ^4",
-        "ramsey/uuid-doctrine": ">=1.5.0",
-        "laminas/laminas-validator": "2.*",
-        "laminas/laminas-dependency-plugin": "^2.1"
-    },
-    "require-dev": {
-        "phpspec/phpspec": "6.1.1",
-        "friends-of-phpspec/phpspec-code-coverage": "@stable",
-        "codacy/coverage": "^1.0",
-        "paragonie/passwdqc": "^0.2.0",
-        "bjeavons/zxcvbn-php": "1.1.0"
-    },
-    "suggest": {
-        "paragonie/passwdqc": "Add built-in support for password-strength checking! See README for configuration details.",
-        "bjeavons/zxcvbn-php": "Even better password checking!",
-        "laminas/laminas-diactoros": "Recommended to support middleware guards.",
-        "laminas/laminas-psr7bridge": "Recommended to support middleware guards.",
-        "laminas/laminas-stratigility": "Recommended to support middleware guards.",
-        "http-interop/http-middleware": "Recommended to support middleware guards."
-    },
-    "autoload": {
-        "psr-4": {
-            "CirclicalUser\\": "src/CirclicalUser"
-        }
+  "name": "saeven/zf3-circlical-user",
+  "description": "Complete user entity, rights, and access module for Laminas",
+  "type": "library",
+  "license": "MPL-2.0",
+  "homepage": "https://github.com/Saeven/zf3-circlical-user",
+  "minimum-stability": "dev",
+  "keywords": [
+    "user",
+    "zf3",
+    "laminas",
+    "user management",
+    "acl",
+    "rbac",
+    "bjyauthorize",
+    "authorization",
+    "auth"
+  ],
+  "authors": [
+    {
+      "name": "Alexandre Lemaire",
+      "email": "alemaire@circlical.com",
+      "homepage": "http://circlical.com/",
+      "role": "Paper Stapler"
     }
+  ],
+  "require": {
+    "ext-json": "*",
+    "php": "^7.4.0 | >=8",
+    "laminas/laminas-eventmanager": "^3.0 | ^3.3",
+    "laminas/laminas-servicemanager": "^3.0 | ^3.3",
+    "laminas/laminas-mvc": "^3.0 | ^3.2",
+    "laminas/laminas-view": "^2.8",
+    "laminas/laminas-http": "^2.5",
+    "laminas/laminas-cache": "^2.11",
+    "doctrine/doctrine-orm-module": ">=2.1.4",
+    "doctrine/doctrine-module": "4.1.2",
+    "doctrine/orm": "2.*",
+    "paragonie/halite": "^3.3 | ^4",
+    "ramsey/uuid": "^3.5 | ^4",
+    "ramsey/uuid-doctrine": ">=1.5.0",
+    "laminas/laminas-validator": "2.*",
+    "laminas/laminas-dependency-plugin": "^2.1"
+  },
+  "replace": {
+    "laminas/laminas-cache-storage-adapter-apc": "*",
+    "laminas/laminas-cache-storage-adapter-apcu": "*",
+    "laminas/laminas-cache-storage-adapter-blackhole": "*",
+    "laminas/laminas-cache-storage-adapter-dba": "*",
+    "laminas/laminas-cache-storage-adapter-ext-mongodb": "*",
+    "laminas/laminas-cache-storage-adapter-filesystem": "*",
+    "laminas/laminas-cache-storage-adapter-memcache": "*",
+    "laminas/laminas-cache-storage-adapter-memcached": "*",
+    "laminas/laminas-cache-storage-adapter-mongodb": "*",
+    "laminas/laminas-cache-storage-adapter-redis": "*",
+    "laminas/laminas-cache-storage-adapter-session": "*",
+    "laminas/laminas-cache-storage-adapter-wincache": "*",
+    "laminas/laminas-cache-storage-adapter-xcache": "*",
+    "laminas/laminas-cache-storage-adapter-zend-server": "*"
+  },
+  "require-dev": {
+    "phpspec/phpspec": "6.1.1 | 7.0.1",
+    "friends-of-phpspec/phpspec-code-coverage": "@stable",
+    "codacy/coverage": "^1.0",
+    "bjeavons/zxcvbn-php": "1.1.0 | 1.2.0"
+  },
+  "suggest": {
+    "paragonie/passwdqc": "Add built-in support for password-strength checking! See README for configuration details.",
+    "bjeavons/zxcvbn-php": "Even better password checking!",
+    "laminas/laminas-diactoros": "Recommended to support middleware guards.",
+    "laminas/laminas-psr7bridge": "Recommended to support middleware guards.",
+    "laminas/laminas-stratigility": "Recommended to support middleware guards.",
+    "http-interop/http-middleware": "Recommended to support middleware guards."
+  },
+  "autoload": {
+    "psr-4": {
+      "CirclicalUser\\": "src/CirclicalUser"
+    }
+  }
 }

--- a/ps
+++ b/ps
@@ -1,0 +1,1 @@
+XDEBUG_MODE=coverage php -dxdebug.mode=debug -dxdebug.client_host=127.0.0.1 -dxdebug.client_port=9003 -dxdebug.start_with_request=yes vendor/bin/phpspec run

--- a/src/CirclicalUser/Entity/UserResetToken.php
+++ b/src/CirclicalUser/Entity/UserResetToken.php
@@ -127,8 +127,13 @@ class UserResetToken implements UserResetTokenInterface
         $this->status = $status;
     }
 
-    public function isValid(AuthenticationRecordInterface $authenticationRecord, string $checkToken, string $requestingIpAddress, bool $validateFingerprint, bool $validateIp): bool
-    {
+    public function isValid(
+        AuthenticationRecordInterface $authenticationRecord,
+        string $checkToken,
+        string $requestingIpAddress,
+        bool $validateFingerprint,
+        bool $validateIp
+    ): bool {
         if ($this->token !== $checkToken) {
             return false;
         }
@@ -139,8 +144,9 @@ class UserResetToken implements UserResetTokenInterface
 
         try {
             $encryptedJson = @base64_decode($checkToken);
-            $key = new EncryptionKey(new HiddenString($authenticationRecord->getRawSessionKey()));
-            $jsonString = Crypto::decrypt($encryptedJson, $key);
+            $sessionKey = new HiddenString($authenticationRecord->getRawSessionKey());
+            $key = new EncryptionKey($sessionKey);
+            $jsonString = Crypto::decrypt($encryptedJson, $key)->getString();
         } catch (\Exception $x) {
             throw new InvalidResetTokenException();
         }

--- a/src/CirclicalUser/Module.php
+++ b/src/CirclicalUser/Module.php
@@ -10,6 +10,25 @@ use Laminas\Mvc\MvcEvent;
 
 class Module
 {
+    protected static $isConsole;
+
+    public static function isConsole(): bool
+    {
+        if (null === static::$isConsole) {
+            static::$isConsole = (PHP_SAPI === 'cli');
+        }
+
+        return static::$isConsole;
+    }
+
+    public static function overrideIsConsole($flag): void
+    {
+        if (null !== $flag) {
+            $flag = (bool)$flag;
+        }
+        static::$isConsole = $flag;
+    }
+
     public function getConfig()
     {
         return include __DIR__ . '/../../config/module.config.php';
@@ -21,7 +40,7 @@ class Module
             Type::addType('uuid_binary', UuidBinaryType::class);
         }
 
-        if (Console::isConsole()) {
+        if (static::isConsole()) {
             return;
         }
 

--- a/src/CirclicalUser/Service/AuthenticationService.php
+++ b/src/CirclicalUser/Service/AuthenticationService.php
@@ -272,7 +272,7 @@ class AuthenticationService
         $systemKey = new EncryptionKey($this->systemEncryptionKey);
         $sessionKey = new HiddenString($authentication->getRawSessionKey());
         $userKey = new EncryptionKey($sessionKey);
-        $hashCookieName = hash_hmac('sha256', $sessionKey . $authentication->getUsername(), $systemKey);
+        $hashCookieName = hash_hmac('sha256', $sessionKey->getString() . $authentication->getUsername(), $systemKey);
         $userTuple = base64_encode(Crypto::encrypt(new HiddenString($authentication->getUserId() . ':' . $hashCookieName), $systemKey));
         $hashCookieContents = base64_encode(Crypto::encrypt(new HiddenString(time() . ':' . $authentication->getUserId() . ':' . $authentication->getUsername()), $userKey));
 
@@ -372,7 +372,7 @@ class AuthenticationService
         // 2. If the user cookie was not tampered with, decrypt its contents with the system key
         //
         try {
-            $userTuple = Crypto::decrypt(base64_decode($_COOKIE[self::COOKIE_USER]), $systemKey);
+            $userTuple = Crypto::decrypt(base64_decode($_COOKIE[self::COOKIE_USER]), $systemKey)->getString();
 
             if (strpos($userTuple, ':') === false) {
                 throw new \LogicException();
@@ -410,7 +410,7 @@ class AuthenticationService
             //
             // 3. Decrypt the hash cookie with the user key
             //
-            $hashedCookieContents = Crypto::decrypt(base64_decode($_COOKIE[$hashCookieName]), $userKey);
+            $hashedCookieContents = Crypto::decrypt(base64_decode($_COOKIE[$hashCookieName]), $userKey)->getString();
             if (!(substr_count($hashedCookieContents, ':') === 2)) {
                 throw new AuthenticationDataException();
             }


### PR DESCRIPTION
Composer updated to add a massive set of laminas/laminas-cache exclusions.  Rather than relying on opt-in w/suggest, they ask developers to use the "replace" method to opt-out. It's not its intended purpose, but we're painted into a corner here. Will test impact on satellite projects after packages gets this PR.

Passwdqc is not yet supported on PHP8, so I'm removing it for now.  zxcvbn is better anyways!

Halite now throws errrors in specific uses of HiddenString, so we are using the getString method to solve that.
laminas/console is deprecated, so we are adding the only method we were using onto the main module (isConsole) for dev.  I'll line it up into a domain-proper location later on.