### PR TITLE
A new assetic module crashes without a route name.  

### DIFF
--- a/bundle/Spec/CirclicalUser/Strategy/RedirectStrategySpec.php
+++ b/bundle/Spec/CirclicalUser/Strategy/RedirectStrategySpec.php
@@ -23,7 +23,7 @@ class RedirectStrategySpec extends ObjectBehavior
 
     function let(Request $request)
     {
-        $this->beConstructedWith('Controller', 'Action');
+        $this->beConstructedWith('Controller', 'Action', 'Login');
         $request->getServer('REQUEST_URI')->willReturn(static::$requestUri);
     }
 
@@ -32,10 +32,7 @@ class RedirectStrategySpec extends ObjectBehavior
         unset($_SERVER['HTTP_X_REQUESTED_WITH']);
         $event->getTarget()->willReturn($application);
         $event->getRequest()->willReturn($request);
-        $event->setRouteMatch(new RouteMatch([
-            'controller' => 'Controller',
-            'action' => 'Action',
-        ]))->shouldBeCalled();
+        $event->setRouteMatch(Argument::type(RouteMatch::class))->shouldBeCalled();
         $event->setParam('authRedirect', true)->shouldBeCalled();
         $event->setParam('authRedirectTo', static::$requestUri)->shouldBeCalled();
         $response->setStatusCode(403)->shouldBeCalled();

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "laminas/laminas-cache-storage-adapter-zend-server": "*"
   },
   "require-dev": {
-    "phpspec/phpspec": "6.1.1 | 7.0.1",
+    "phpspec/phpspec": "7.0.1",
     "friends-of-phpspec/phpspec-code-coverage": "@stable",
     "codacy/coverage": "^1.0",
     "bjeavons/zxcvbn-php": "1.1.0 | 1.2.0"

--- a/config/circlical.user.local.php.dist
+++ b/config/circlical.user.local.php.dist
@@ -124,6 +124,7 @@ return [
 //                'options' => [
 //                    'controller' => \Application\Controller\LoginController::class,
 //                    'action' => 'index',
+//                    'name' => 'login',
 //                ]
             ],
 

--- a/src/CirclicalUser/Factory/Strategy/RedirectStrategyFactory.php
+++ b/src/CirclicalUser/Factory/Strategy/RedirectStrategyFactory.php
@@ -16,6 +16,6 @@ class RedirectStrategyFactory implements FactoryInterface
         }
         $appliedOptions = $config['circlical']['user']['deny_strategy']['options'];
 
-        return new RedirectStrategy($appliedOptions['controller'], $appliedOptions['action']);
+        return new RedirectStrategy($appliedOptions['controller'], $appliedOptions['action'], $appliedOptions['name'] ?? 'login-redirect');
     }
 }

--- a/src/CirclicalUser/Strategy/RedirectStrategy.php
+++ b/src/CirclicalUser/Strategy/RedirectStrategy.php
@@ -19,21 +19,22 @@ class RedirectStrategy implements DenyStrategyInterface
 {
     /**
      * The controller that dispatch should invoke
-     * @var string
      */
-    protected $controllerClass;
+    protected string $controllerClass;
 
     /**
      * This ^ controller's action
-     * @var string
      */
-    protected $action;
+    protected string $action;
+
+    private string $routeName;
 
 
-    public function __construct(string $controllerClass, string $action)
+    public function __construct(string $controllerClass, string $action, string $routeName)
     {
         $this->controllerClass = $controllerClass;
         $this->action = $action;
+        $this->routeName = $routeName;
     }
 
     public function handle(MvcEvent $event, string $eventError): bool
@@ -43,14 +44,13 @@ class RedirectStrategy implements DenyStrategyInterface
             if ($response instanceof Response) {
                 $response->setStatusCode(403);
             }
-            $event->setRouteMatch(
-                new RouteMatch(
-                    [
-                        'controller' => $this->controllerClass,
-                        'action' => $this->action,
-                    ]
-                )
-            );
+
+            $routeMatch = new RouteMatch([
+                'controller' => $this->controllerClass,
+                'action' => $this->action,
+            ]);
+            $routeMatch->setMatchedRouteName($this->routeName);
+            $event->setRouteMatch($routeMatch);
             $event->setParam('authRedirect', true);
 
             /** @var \Laminas\Http\PhpEnvironment\Request $requestData */


### PR DESCRIPTION
Though it shouldn't be required, it's pretty painless to add it.  Am picking the lesser evil here.