### PR TITLE
Laminas coding style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ composer.lock
 vendor
 .idea
 /build
+/tmp
 .vagrant
 nbproject
 phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
       "role": "Paper Stapler"
     }
   ],
+  "prefer-stable": true,
   "require": {
     "ext-json": "*",
     "php": "^7.4.0 | >=8",
@@ -62,7 +63,10 @@
     "phpspec/phpspec": "7.0.1",
     "friends-of-phpspec/phpspec-code-coverage": "@stable",
     "codacy/coverage": "^1.0",
-    "bjeavons/zxcvbn-php": "1.1.0 | 1.2.0"
+    "bjeavons/zxcvbn-php": "1.1.0 | 1.2.0",
+    "laminas/laminas-coding-standard": "^2.3.0",
+    "squizlabs/php_codesniffer": "3.*",
+    "phpstan/phpstan": "^1.0.2"
   },
   "suggest": {
     "paragonie/passwdqc": "Add built-in support for password-strength checking! See README for configuration details.",
@@ -76,5 +80,16 @@
     "psr-4": {
       "CirclicalUser\\": "src/CirclicalUser"
     }
+  },
+  "scripts": {
+    "check": [
+      "@stan-min",
+      "@test"
+    ],
+    "cs-check": "vendor/bin/phpcs",
+    "cs-fix": "vendor/bin/phpcbf",
+    "stan-max": "vendor/bin/phpstan analyse -c phpstan.neon --level max --memory-limit 1G --xdebug --ansi -vvv",
+    "stan-next": "vendor/bin/phpstan analyse -c phpstan.neon --level 4 --memory-limit 1G --xdebug --ansi -vvv",
+    "stan-min": "vendor/bin/phpstan analyse -c phpstan.neon --level 3 --memory-limit 1G --xdebug --ansi -vvv"
   }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,6 +14,18 @@
     <!-- Paths to check -->
     <file>src</file>
 
+    <rule ref="PSR2">
+        <!-- or to disable the whole sniff -->
+        <exclude name="Generic.Files.LineLength"/>
+    </rule>
+
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="220"/>
+            <property name="absoluteLineLimit" value="220"/>
+        </properties>
+    </rule>
+
     <!-- Include all rules from the Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,27 +1,19 @@
 <?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 
-<ruleset name="PHP_CodeSniffer">
+    <arg name="basepath" value="."/>
+    <arg name="cache" value="tmp/.phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
 
-    <description>PHPCS configuration file.</description>
-    <!-- check all files in the app directory, feel free to add more files with:
-    <file>FOLDER NAME</file>
-    -->
-    <file>module</file>
+    <!-- Show progress -->
+    <arg value="p"/>
 
-    <!-- exclude our migrations directory from the violation check-->
-    <!-- <exclude-pattern></exclude-pattern> -->
+    <!-- Paths to check -->
+    <file>src</file>
 
-    <!-- ignore warnings and display ERRORS only -->
-    <!-- <arg value="np"/> -->
-
-    <!-- Our base rule: set to PSR12-->
-    <rule ref="PSR12"/>
-
-    <rule ref="Generic.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="220"/>
-            <property name="absoluteLineLimit" value="220"/>
-        </properties>
-    </rule>
-
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
-  autoload_files:
-    - %rootDir%/../../../vendor/autoload.php
-  #  excludes_analyse:
-  level: 5
-  ignoreErrors:
+    parallel:
+          processTimeout: 180.0
+    tmpDir: tmp/phpstan
+    paths:
+        - src


### PR DESCRIPTION
fixes #81 

1. adds phpcodesniffer with laminas codings style
2. adds phpstan for testing
3. updates composer to prefer stable versions